### PR TITLE
Use head() instead of render(nothing: true)

### DIFF
--- a/lib/spamtrap/controller.rb
+++ b/lib/spamtrap/controller.rb
@@ -11,7 +11,7 @@ module Spamtrap::Controller
         controller.instance_eval do
           if params[honeypot].present?
             Rails.logger.warn "Spamtrap triggered by #{request.remote_ip}."
-            render :nothing => true, :status => 200
+            head 200
           end
         end
       end

--- a/lib/spamtrap/version.rb
+++ b/lib/spamtrap/version.rb
@@ -1,5 +1,5 @@
 module Spamtrap
 
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 
 end


### PR DESCRIPTION
👋 

Currently we have a `POST`-only endpoint that's getting spamtrapped. When spamtrap is triggered, it calls `render(nothing: true, status: 200)`, and `render` does a layout lookup, but this endpoint doesn't have a layout, so an `ActionView::MissingTemplate: Missing template controller_name/action` error is raised. I think using `head` instead avoids calling `render`. 

Version: Rails 5.1.6