### PR TITLE
Nonce replay protection, field name mutation, and fields_for propagation (v0.3.0)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spamtrap (0.3.0)
+    spamtrap (0.4.0)
       rails (>= 7.0)
 
 GEM
@@ -287,7 +287,7 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  spamtrap (0.3.0)
+  spamtrap (0.4.0)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.0) sha256=6d722ad619f96ee383a0c557ec6eb8c4ecb08af3af62098a0be5057bf00de1af

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spamtrap (0.4.0)
+    spamtrap (0.3.0)
       rails (>= 7.0)
 
 GEM
@@ -287,7 +287,7 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  spamtrap (0.4.0)
+  spamtrap (0.3.0)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.0) sha256=6d722ad619f96ee383a0c557ec6eb8c4ecb08af3af62098a0be5057bf00de1af

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spamtrap (0.2.0)
+    spamtrap (0.3.0)
       rails (>= 7.0)
 
 GEM
@@ -287,7 +287,7 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  spamtrap (0.2.0)
+  spamtrap (0.3.0)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.0) sha256=6d722ad619f96ee383a0c557ec6eb8c4ecb08af3af62098a0be5057bf00de1af

--- a/README.rdoc
+++ b/README.rdoc
@@ -31,9 +31,40 @@ Now you just need to hide the spamtrap from your real users by adding this to yo
 
 The spamtrap mix-in can also take an optional block, where you can do more advance things -- like swapping the honeypot with a real form parameter.
 
+=== Replay Attack Protection (Nonce)
+
+Enable cryptographic nonce validation to prevent replay attacks. The nonce is an HMAC-SHA256
+digest of the form submission timestamp and the client IP address, keyed with
+<tt>Rails.application.secret_key_base</tt>. Submissions with an expired or tampered nonce are
+silently discarded with a 200 response.
+
+Enable it per-controller:
+
+  class CommentsController < ApplicationController
+    spamtrap :sarah_palin_walks_with_dinosaurs, nonce: true, only: %i(create update)
+  end
+
+And add the nonce fields to your form:
+
+  - form_for @comment do |f|
+    = f.spamtrap :sarah_palin_walks_with_dinosaurs, nonce: true, class: 'reindeer_jerky'
+
+Override the timeout for a specific controller action (accepts any value in seconds, or an
+ActiveSupport duration):
+
+  spamtrap :field, nonce: true, nonce_timeout: 15.minutes, only: %i(create)
+
+Set a global default timeout in an initializer (default is 1800 seconds / 30 minutes):
+
+  # config/initializers/spamtrap.rb
+  Spamtrap.nonce_timeout = 1.hour
+
+Note: because the nonce binds to the client IP, users whose IP address changes between page load
+and form submission (e.g. mobile network handoffs) will be rejected. This is an acceptable
+trade-off for spam protection but may not suit all deployments.
+
 === To Do
 
-- Add a cryptographic nonce to prevent replay attacks. It would probably be an MD5 hash consisting of a timestamp, ip address and a secret token. The timeout would be configurable.
 - Consider field name mutation throughout form.
 
 === License

--- a/README.rdoc
+++ b/README.rdoc
@@ -63,9 +63,46 @@ Note: because the nonce binds to the client IP, users whose IP address changes b
 and form submission (e.g. mobile network handoffs) will be rejected. This is an acceptable
 trade-off for spam protection but may not suit all deployments.
 
+=== Field Name Mutation
+
+Enable field name mutation to make all form fields unrecognizable in HTML source. Every field
+is encrypted with AES-128-GCM using a random per-render salt, so field names change on every
+page load. The controller decrypts and remaps them transparently before the action runs — no
+changes to <tt>params.require(...).permit(...)</tt> or any other controller code required.
+
+Enable mutation in the controller:
+
+  class CommentsController < ApplicationController
+    spamtrap :sarah_palin_walks_with_dinosaurs, mutate: true, only: %i(create update)
+  end
+
+Enable it in the view by passing <tt>mutate: true</tt> to <tt>f.spamtrap</tt>:
+
+  - form_for @comment do |f|
+    = f.spamtrap :sarah_palin_walks_with_dinosaurs, mutate: true
+    = f.label :body
+    = f.text_area :body
+    = f.label :email
+    = f.email_field :email
+    = f.submit
+
+The rendered HTML will contain opaque encrypted field names (~28 characters each) instead of
+<tt>body</tt>, <tt>email</tt>, etc. The encryption key is derived from
+<tt>secret_key_base</tt> so only the originating server can decrypt submissions.
+
+Mutation can be combined with the nonce for full replay and bot protection:
+
+  spamtrap :field, mutate: true, nonce: true, only: %i(create update)
+
+  = f.spamtrap :field, mutate: true, nonce: true
+
+Note: <tt>fields_for</tt> (nested attributes) creates a child FormBuilder instance that does
+not yet inherit the mutation salt. Nested forms are a known limitation of the current
+implementation.
+
 === To Do
 
-- Consider field name mutation throughout form.
+- Propagate mutation salt to <tt>fields_for</tt> child builders.
 
 === License
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,16 @@
 == Spamtrap
 
-This is a simple {spamtrap}[http://en.wikipedia.org/wiki/Spamtrap] to fight {spamdexing}[http://en.wikipedia.org/wiki/Spamdexing]. You can create bogus form fields ({honeypots}[http://en.wikipedia.org/wiki/Honeypot_%28computing%29]) that will be filled-in by spambots. When these forms are submitted, the content will be discarded while still returning a 200 response.
+Spamtrap is a Rails gem that protects forms from spambots through three complementary mechanisms:
+
+- *Honeypot fields* — hidden textarea fields that real users never touch. Bots that fill them in
+  are silently discarded with a <tt>200 OK</tt> response.
+- *Cryptographic nonce* — an HMAC-SHA256 token binding each submission to a timestamp and client
+  IP. Replayed or expired submissions are rejected before reaching the controller.
+- *Field name mutation* — all form field names are AES-128-GCM encrypted on every page render,
+  so bots cannot target fields by recognizable names like <tt>email</tt> or <tt>body</tt>. The
+  controller remaps them back transparently; no changes to application code are required.
+
+Each feature is opt-in and can be used independently or combined.
 
 === Installation
 
@@ -90,9 +100,8 @@ Mutation can be combined with the nonce for full replay and bot protection:
 
   = f.spamtrap :field, mutate: true, nonce: true
 
-Note: <tt>fields_for</tt> (nested attributes) creates a child FormBuilder instance that does
-not yet inherit the mutation salt. Nested forms are a known limitation of the current
-implementation.
+Mutation propagates automatically to <tt>fields_for</tt> nested builders, so nested
+attributes forms are mutated at every level without any additional configuration.
 
 === Example
 
@@ -109,10 +118,6 @@ fields:
 Now you just need to hide the spamtrap from your real users by adding this to your CSS:
 
   .reindeer_jerky { display: none; }
-
-=== To Do
-
-- Propagate mutation salt to <tt>fields_for</tt> child builders.
 
 === License
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -8,28 +8,22 @@ Add the following to your Gemfile:
 
   gem 'spamtrap'
 
-=== Example
+=== Honeypot
 
-Declare the controller actions you want the spamtrap enabled for:
+A hidden textarea is added to the form with a deliberately enticing name. Real users never see
+or interact with it (it is hidden via CSS). Spambots, which auto-fill all visible and hidden
+fields, will populate it. When the form is submitted with a non-empty honeypot field, spamtrap
+silently discards the submission and returns a <tt>200 OK</tt> response — indistinguishable
+from a successful submission to the bot.
+
+Declare the controller actions you want protected:
 
   class CommentsController < ApplicationController
     spamtrap :sarah_palin_walks_with_dinosaurs, only: %i(create update)
   end
 
-In your views, add a call to the "spamtrap" form builder to your forms to output the honeypot fields:
-
-  - form_for @comment do |f|
-    = f.spamtrap :sarah_palin_walks_with_dinosaurs, class: 'reindeer_jerky'
-    %fieldset
-      = f.label :body
-      = f.text_area :body
-    = f.submit
-
-Now you just need to hide the spamtrap from your real users by adding this to your CSS:
-
-  .reindeer_jerky { display: none; }
-
-The spamtrap mix-in can also take an optional block, where you can do more advance things -- like swapping the honeypot with a real form parameter.
+The macro accepts an optional block for advanced use cases, such as swapping the honeypot with
+a real form parameter at runtime.
 
 === Replay Attack Protection (Nonce)
 
@@ -100,6 +94,22 @@ Note: <tt>fields_for</tt> (nested attributes) creates a child FormBuilder instan
 not yet inherit the mutation salt. Nested forms are a known limitation of the current
 implementation.
 
+=== Example
+
+In your views, add a call to the "spamtrap" form builder to your forms to output the honeypot
+fields:
+
+  - form_for @comment do |f|
+    = f.spamtrap :sarah_palin_walks_with_dinosaurs, class: 'reindeer_jerky'
+    %fieldset
+      = f.label :body
+      = f.text_area :body
+    = f.submit
+
+Now you just need to hide the spamtrap from your real users by adding this to your CSS:
+
+  .reindeer_jerky { display: none; }
+
 === To Do
 
 - Propagate mutation salt to <tt>fields_for</tt> child builders.
@@ -128,4 +138,3 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/README.rdoc
+++ b/README.rdoc
@@ -32,6 +32,19 @@ Declare the controller actions you want protected:
     spamtrap :sarah_palin_walks_with_dinosaurs, only: %i(create update)
   end
 
+Add the honeypot field to your form using the <tt>f.spamtrap</tt> form builder helper:
+
+  - form_for @comment do |f|
+    = f.spamtrap :sarah_palin_walks_with_dinosaurs, class: 'reindeer_jerky'
+    %fieldset
+      = f.label :body
+      = f.text_area :body
+    = f.submit
+
+Hide it from real users with CSS:
+
+  .reindeer_jerky { display: none; }
+
 The macro accepts an optional block for advanced use cases, such as swapping the honeypot with
 a real form parameter at runtime.
 
@@ -102,22 +115,6 @@ Mutation can be combined with the nonce for full replay and bot protection:
 
 Mutation propagates automatically to <tt>fields_for</tt> nested builders, so nested
 attributes forms are mutated at every level without any additional configuration.
-
-=== Example
-
-In your views, add a call to the "spamtrap" form builder to your forms to output the honeypot
-fields:
-
-  - form_for @comment do |f|
-    = f.spamtrap :sarah_palin_walks_with_dinosaurs, class: 'reindeer_jerky'
-    %fieldset
-      = f.label :body
-      = f.text_area :body
-    = f.submit
-
-Now you just need to hide the spamtrap from your real users by adding this to your CSS:
-
-  .reindeer_jerky { display: none; }
 
 === License
 

--- a/lib/spamtrap.rb
+++ b/lib/spamtrap.rb
@@ -9,6 +9,7 @@ module Spamtrap
     end
   end
 
+  require 'spamtrap/crypto'
   require 'spamtrap/controller'
   require 'spamtrap/helper'
 end

--- a/lib/spamtrap.rb
+++ b/lib/spamtrap.rb
@@ -1,4 +1,14 @@
+require 'openssl'
+
 module Spamtrap
+  class << self
+    attr_writer :nonce_timeout
+
+    def nonce_timeout
+      @nonce_timeout || 1800
+    end
+  end
+
   require 'spamtrap/controller'
   require 'spamtrap/helper'
 end

--- a/lib/spamtrap/controller.rb
+++ b/lib/spamtrap/controller.rb
@@ -6,17 +6,36 @@ module Spamtrap::Controller
 
   module ActsAsMethods
     def spamtrap(honeypot = 'spamtrap', options = {}, &block)
+      nonce_enabled = options.delete(:nonce)
+      nonce_timeout = options.delete(:nonce_timeout) || Spamtrap.nonce_timeout
+
       before_action(options) do |controller|
         controller.instance_eval(&block) if block_given?
         controller.instance_eval do
           if params[honeypot].present?
             Rails.logger.warn "Spamtrap triggered by #{request.remote_ip}."
             head 200
+          elsif nonce_enabled && !spamtrap_valid_nonce?(nonce_timeout)
+            Rails.logger.warn "Spamtrap nonce invalid from #{request.remote_ip}."
+            head 200
           end
         end
       end
     end
   end
+
+  def spamtrap_valid_nonce?(timeout)
+    timestamp = params[:spamtrap_timestamp].to_i
+    nonce = params[:spamtrap_nonce].to_s
+    return false if timestamp.zero? || nonce.empty?
+    return false if Time.now.to_i - timestamp > timeout.to_i
+
+    secret = Rails.application.secret_key_base
+    expected = OpenSSL::HMAC.hexdigest('SHA256', secret, "#{timestamp}:#{request.remote_ip}")
+    ActiveSupport::SecurityUtils.secure_compare(nonce, expected)
+  end
+
+  private :spamtrap_valid_nonce?
 
 end
 

--- a/lib/spamtrap/controller.rb
+++ b/lib/spamtrap/controller.rb
@@ -1,4 +1,5 @@
 module Spamtrap::Controller
+  include Spamtrap::Crypto
 
   def self.included(base)
     base.extend ActsAsMethods
@@ -6,12 +7,15 @@ module Spamtrap::Controller
 
   module ActsAsMethods
     def spamtrap(honeypot = 'spamtrap', options = {}, &block)
-      nonce_enabled = options.delete(:nonce)
-      nonce_timeout = options.delete(:nonce_timeout) || Spamtrap.nonce_timeout
+      nonce_enabled  = options.delete(:nonce)
+      nonce_timeout  = options.delete(:nonce_timeout) || Spamtrap.nonce_timeout
+      mutate_enabled = options.delete(:mutate)
 
       before_action(options) do |controller|
         controller.instance_eval(&block) if block_given?
         controller.instance_eval do
+          spamtrap_remap_params if mutate_enabled
+
           if params[honeypot].present?
             Rails.logger.warn "Spamtrap triggered by #{request.remote_ip}."
             head 200
@@ -35,7 +39,31 @@ module Spamtrap::Controller
     ActiveSupport::SecurityUtils.secure_compare(nonce, expected)
   end
 
-  private :spamtrap_valid_nonce?
+  def spamtrap_remap_params
+    salt_hex = params[:spamtrap_mutation_salt].to_s
+    return if salt_hex.empty?
+
+    salt_bytes = [salt_hex].pack('H*')
+    return unless salt_bytes.bytesize == Spamtrap::Crypto::NONCE_LEN
+
+    spamtrap_remap_hash(params, salt_bytes)
+  rescue ArgumentError
+    nil
+  end
+
+  def spamtrap_remap_hash(hash, salt)
+    hash.each_key.to_a.each do |key|
+      real = spamtrap_decrypt_field(key.to_s, salt)
+      if real
+        hash[real] = hash.delete(key)
+        key = real
+      end
+      child = hash[key]
+      spamtrap_remap_hash(child, salt) if child.is_a?(ActionController::Parameters)
+    end
+  end
+
+  private :spamtrap_valid_nonce?, :spamtrap_remap_params, :spamtrap_remap_hash
 
 end
 

--- a/lib/spamtrap/crypto.rb
+++ b/lib/spamtrap/crypto.rb
@@ -1,0 +1,46 @@
+require 'base64'
+
+module Spamtrap
+  module Crypto
+    CIPHER    = 'aes-128-gcm'
+    KEY_LEN   = 16
+    NONCE_LEN = 12
+    TAG_LEN   = 16
+
+    private
+
+    def spamtrap_crypto_key
+      @spamtrap_crypto_key ||= OpenSSL::KDF.hkdf(
+        Rails.application.secret_key_base,
+        salt:   'spamtrap-mutation',
+        info:   '',
+        length: KEY_LEN,
+        hash:   'SHA256'
+      )
+    end
+
+    def spamtrap_encrypt_field(field_name, salt_bytes)
+      cipher = OpenSSL::Cipher.new(CIPHER)
+      cipher.encrypt
+      cipher.key = spamtrap_crypto_key
+      cipher.iv  = salt_bytes
+      ct = cipher.update(field_name.to_s) + cipher.final
+      Base64.urlsafe_encode64(ct + cipher.auth_tag(TAG_LEN), padding: false)
+    end
+
+    def spamtrap_decrypt_field(token, salt_bytes)
+      raw = Base64.urlsafe_decode64(token)
+      return nil if raw.bytesize <= TAG_LEN
+      ct  = raw[0, raw.bytesize - TAG_LEN]
+      tag = raw[-TAG_LEN..]
+      cipher = OpenSSL::Cipher.new(CIPHER)
+      cipher.decrypt
+      cipher.key      = spamtrap_crypto_key
+      cipher.iv       = salt_bytes
+      cipher.auth_tag = tag
+      (cipher.update(ct) + cipher.final).to_sym
+    rescue OpenSSL::Cipher::CipherError, ArgumentError
+      nil
+    end
+  end
+end

--- a/lib/spamtrap/helper.rb
+++ b/lib/spamtrap/helper.rb
@@ -1,17 +1,20 @@
 class ActionView::Helpers::FormBuilder
-  def spamtrap(parameter='spamtrap', options={})
-    options.reverse_merge!({:class => 'spamtrap'})
-    @template.text_area_tag(parameter, nil, options)
+  def spamtrap(parameter = 'spamtrap', options = {})
+    nonce = options.delete(:nonce)
+    options.reverse_merge!(class: 'spamtrap')
+    honeypot = @template.text_area_tag(parameter, nil, options)
+    nonce ? honeypot + spamtrap_nonce_fields : honeypot
   end
 
-  # # def nonce(method, tag_value, options = {})
-  # def cryptographic_nonce(options = {})
-  #   # @template.hidden_field(@object_name, method, tag_value, objectify_options(options))
-  #   now, random = Time.now.to_i, SecureRandom.hex
-  #   # OpenSSL::HMAC.hexdigest()
-  #   cryptographic_nonce = Digest::MD5.hexdigest([timestamp, Rails.application.config.secret_key_base].join(':'))
-  #   @template.hidden_field(@object_name, :timestamp, now, objectify_options(options)) +
-  #   @template.hidden_field(@object_name, :random, random, objectify_options(options)) +
-  #   @template.hidden_field(@object_name, :spinner, cryptographic_nonce(now), objectify_options(options))
-  # end
+  private
+
+  def spamtrap_nonce_fields
+    timestamp = Time.now.to_i
+    ip = @template.request.remote_ip
+    secret = Rails.application.secret_key_base
+    nonce = OpenSSL::HMAC.hexdigest('SHA256', secret, "#{timestamp}:#{ip}")
+
+    @template.hidden_field_tag(:spamtrap_timestamp, timestamp) +
+      @template.hidden_field_tag(:spamtrap_nonce, nonce)
+  end
 end

--- a/lib/spamtrap/helper.rb
+++ b/lib/spamtrap/helper.rb
@@ -15,6 +15,22 @@ module Spamtrap
         super(field, *args, &blk)
       end
     end
+
+    def initialize(object_name, object, template, options)
+      super
+      @spamtrap_salt = options[:spamtrap_salt] if options[:spamtrap_salt]
+    end
+
+    def fields_for(record_name, record_object = nil, fields_options = {}, &block)
+      if @spamtrap_salt
+        if record_object.is_a?(Hash) && record_object.extractable_options?
+          record_object = record_object.merge(spamtrap_salt: @spamtrap_salt)
+        else
+          fields_options = fields_options.merge(spamtrap_salt: @spamtrap_salt)
+        end
+      end
+      super(record_name, record_object, fields_options, &block)
+    end
   end
 end
 

--- a/lib/spamtrap/helper.rb
+++ b/lib/spamtrap/helper.rb
@@ -1,18 +1,50 @@
+module Spamtrap
+  module FormBuilderMutation
+    include Spamtrap::Crypto
+
+    MUTABLE_FIELDS = %i[
+      text_field email_field password_field number_field url_field telephone_field
+      text_area check_box hidden_field file_field date_field time_field
+      datetime_local_field month_field week_field search_field color_field
+      range_field select collection_select grouped_collection_select label
+    ].freeze
+
+    MUTABLE_FIELDS.each do |m|
+      define_method(m) do |field, *args, &blk|
+        field = spamtrap_encrypt_field(field.to_s, @spamtrap_salt) if @spamtrap_salt
+        super(field, *args, &blk)
+      end
+    end
+  end
+end
+
 class ActionView::Helpers::FormBuilder
+  prepend Spamtrap::FormBuilderMutation
+
   def spamtrap(parameter = 'spamtrap', options = {})
-    nonce = options.delete(:nonce)
+    mutate = options.delete(:mutate)
+    nonce  = options.delete(:nonce)
     options.reverse_merge!(class: 'spamtrap')
-    honeypot = @template.text_area_tag(parameter, nil, options)
-    nonce ? honeypot + spamtrap_nonce_fields : honeypot
+
+    if mutate
+      @spamtrap_salt = SecureRandom.bytes(Spamtrap::Crypto::NONCE_LEN)
+      salt_field = @template.hidden_field_tag(
+        :spamtrap_mutation_salt, @spamtrap_salt.unpack1('H*')
+      )
+    end
+
+    @template.text_area_tag(parameter, nil, options) +
+      (nonce ? spamtrap_nonce_fields : ''.html_safe) +
+      (salt_field || ''.html_safe)
   end
 
   private
 
   def spamtrap_nonce_fields
     timestamp = Time.now.to_i
-    ip = @template.request.remote_ip
-    secret = Rails.application.secret_key_base
-    nonce = OpenSSL::HMAC.hexdigest('SHA256', secret, "#{timestamp}:#{ip}")
+    ip        = @template.request.remote_ip
+    secret    = Rails.application.secret_key_base
+    nonce     = OpenSSL::HMAC.hexdigest('SHA256', secret, "#{timestamp}:#{ip}")
 
     @template.hidden_field_tag(:spamtrap_timestamp, timestamp) +
       @template.hidden_field_tag(:spamtrap_nonce, nonce)

--- a/lib/spamtrap/version.rb
+++ b/lib/spamtrap/version.rb
@@ -1,5 +1,5 @@
 module Spamtrap
 
-  VERSION = '0.4.1'
+  VERSION = '0.3.0'
 
 end

--- a/lib/spamtrap/version.rb
+++ b/lib/spamtrap/version.rb
@@ -1,5 +1,5 @@
 module Spamtrap
 
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 
 end

--- a/lib/spamtrap/version.rb
+++ b/lib/spamtrap/version.rb
@@ -1,5 +1,5 @@
 module Spamtrap
 
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 
 end

--- a/lib/spamtrap/version.rb
+++ b/lib/spamtrap/version.rb
@@ -1,5 +1,5 @@
 module Spamtrap
 
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -36,6 +36,17 @@ class MutationController < ActionController::Base
   end
 end
 
+class NestedMutationController < ActionController::Base
+  spamtrap :trap_field, mutate: true, only: :create
+
+  def create
+    # Render top-level and nested address keys to verify salt propagation
+    comment_keys = params[:comment].to_unsafe_h.except('address').keys.sort
+    address_keys = params.dig(:comment, :address).to_unsafe_h.keys.sort rescue []
+    render plain: "#{comment_keys.join(',')};#{address_keys.join(',')}"
+  end
+end
+
 module NonceTestHelper
   REMOTE_IP = '0.0.0.0'
 
@@ -43,6 +54,13 @@ module NonceTestHelper
     secret = Rails.application.secret_key_base
     OpenSSL::HMAC.hexdigest('SHA256', secret, "#{timestamp}:#{ip}")
   end
+end
+
+module MutationTestHelper
+  include Spamtrap::Crypto
+
+  MUTATION_SALT     = SecureRandom.bytes(Spamtrap::Crypto::NONCE_LEN)
+  MUTATION_SALT_HEX = MUTATION_SALT.unpack1('H*')
 end
 
 class HoneypotControllerTest < ActionController::TestCase
@@ -144,11 +162,8 @@ class NonceTimeoutControllerTest < ActionController::TestCase
 end
 
 class MutationControllerTest < ActionController::TestCase
-  include Spamtrap::Crypto
+  include MutationTestHelper
   tests MutationController
-
-  MUTATION_SALT = SecureRandom.bytes(Spamtrap::Crypto::NONCE_LEN)
-  MUTATION_SALT_HEX = MUTATION_SALT.unpack1('H*')
 
   def test_encrypted_field_names_are_remapped_to_real_names
     body_token  = spamtrap_encrypt_field('body',  MUTATION_SALT)
@@ -199,5 +214,31 @@ class MutationControllerTest < ActionController::TestCase
 
     assert_response :ok
     refute_equal 'body', response.body
+  end
+end
+
+class NestedMutationControllerTest < ActionController::TestCase
+  include MutationTestHelper
+  tests NestedMutationController
+
+  def test_salt_propagates_to_fields_for_child_builder
+    body_token    = spamtrap_encrypt_field('body',    MUTATION_SALT)
+    street_token  = spamtrap_encrypt_field('street',  MUTATION_SALT)
+    city_token    = spamtrap_encrypt_field('city',    MUTATION_SALT)
+
+    post :create, params: {
+      trap_field: '',
+      spamtrap_mutation_salt: MUTATION_SALT_HEX,
+      comment: {
+        body_token => 'Hello',
+        address: {
+          street_token => '123 Main St',
+          city_token   => 'Springfield'
+        }
+      }
+    }
+
+    assert_response :ok
+    assert_equal 'body;city,street', response.body
   end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -1,10 +1,135 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 
-class ControllerTest < Minitest::Test
+# Test controllers — render a body so we can distinguish a real response
+# from a spamtrap-blocked one (which uses head 200 and has an empty body).
 
-  def test_foobar
-    assert true
-    assert_equal "hello", "hello"
+class HoneypotController < ActionController::Base
+  spamtrap :trap_field, only: :create
+
+  def create
+    render plain: 'success'
+  end
+end
+
+class NonceController < ActionController::Base
+  spamtrap :trap_field, nonce: true, only: :create
+
+  def create
+    render plain: 'success'
+  end
+end
+
+class NonceTimeoutController < ActionController::Base
+  spamtrap :trap_field, nonce: true, nonce_timeout: 60, only: :create
+
+  def create
+    render plain: 'success'
+  end
+end
+
+module NonceTestHelper
+  REMOTE_IP = '0.0.0.0'
+
+  def generate_nonce(timestamp, ip = REMOTE_IP)
+    secret = Rails.application.secret_key_base
+    OpenSSL::HMAC.hexdigest('SHA256', secret, "#{timestamp}:#{ip}")
+  end
+end
+
+class HoneypotControllerTest < ActionController::TestCase
+  tests HoneypotController
+
+  def test_empty_honeypot_allows_request
+    post :create, params: { trap_field: '' }
+    assert_response :ok
+    assert_equal 'success', response.body
   end
 
+  def test_filled_honeypot_silently_discards
+    post :create, params: { trap_field: 'buy cheap meds' }
+    assert_response :ok
+    assert_empty response.body
+  end
+end
+
+class NonceControllerTest < ActionController::TestCase
+  include NonceTestHelper
+  tests NonceController
+
+  def test_valid_nonce_allows_request
+    timestamp = Time.now.to_i
+    post :create, params: {
+      trap_field: '',
+      spamtrap_timestamp: timestamp,
+      spamtrap_nonce: generate_nonce(timestamp)
+    }
+    assert_response :ok
+    assert_equal 'success', response.body
+  end
+
+  def test_tampered_nonce_is_rejected
+    timestamp = Time.now.to_i
+    post :create, params: {
+      trap_field: '',
+      spamtrap_timestamp: timestamp,
+      spamtrap_nonce: 'deadbeef'
+    }
+    assert_response :ok
+    assert_empty response.body
+  end
+
+  def test_expired_nonce_is_rejected
+    timestamp = Time.now.to_i - 7200
+    post :create, params: {
+      trap_field: '',
+      spamtrap_timestamp: timestamp,
+      spamtrap_nonce: generate_nonce(timestamp)
+    }
+    assert_response :ok
+    assert_empty response.body
+  end
+
+  def test_missing_nonce_fields_are_rejected
+    post :create, params: { trap_field: '' }
+    assert_response :ok
+    assert_empty response.body
+  end
+
+  def test_filled_honeypot_takes_priority_over_valid_nonce
+    timestamp = Time.now.to_i
+    post :create, params: {
+      trap_field: 'spam',
+      spamtrap_timestamp: timestamp,
+      spamtrap_nonce: generate_nonce(timestamp)
+    }
+    assert_response :ok
+    assert_empty response.body
+  end
+end
+
+class NonceTimeoutControllerTest < ActionController::TestCase
+  include NonceTestHelper
+  tests NonceTimeoutController
+
+  def test_nonce_within_custom_timeout_passes
+    timestamp = Time.now.to_i - 30
+    post :create, params: {
+      trap_field: '',
+      spamtrap_timestamp: timestamp,
+      spamtrap_nonce: generate_nonce(timestamp)
+    }
+    assert_response :ok
+    assert_equal 'success', response.body
+  end
+
+  def test_nonce_beyond_custom_timeout_is_rejected
+    timestamp = Time.now.to_i - 120
+    post :create, params: {
+      trap_field: '',
+      spamtrap_timestamp: timestamp,
+      spamtrap_nonce: generate_nonce(timestamp)
+    }
+    assert_response :ok
+    assert_empty response.body
+  end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -27,6 +27,15 @@ class NonceTimeoutController < ActionController::Base
   end
 end
 
+class MutationController < ActionController::Base
+  spamtrap :trap_field, mutate: true, only: :create
+
+  def create
+    # Render the remapped comment param keys so tests can assert on them
+    render plain: params[:comment].to_unsafe_h.keys.sort.join(',')
+  end
+end
+
 module NonceTestHelper
   REMOTE_IP = '0.0.0.0'
 
@@ -131,5 +140,64 @@ class NonceTimeoutControllerTest < ActionController::TestCase
     }
     assert_response :ok
     assert_empty response.body
+  end
+end
+
+class MutationControllerTest < ActionController::TestCase
+  include Spamtrap::Crypto
+  tests MutationController
+
+  MUTATION_SALT = SecureRandom.bytes(Spamtrap::Crypto::NONCE_LEN)
+  MUTATION_SALT_HEX = MUTATION_SALT.unpack1('H*')
+
+  def test_encrypted_field_names_are_remapped_to_real_names
+    body_token  = spamtrap_encrypt_field('body',  MUTATION_SALT)
+    email_token = spamtrap_encrypt_field('email', MUTATION_SALT)
+
+    post :create, params: {
+      trap_field: '',
+      spamtrap_mutation_salt: MUTATION_SALT_HEX,
+      comment: { body_token => 'Hello world', email_token => 'test@example.com' }
+    }
+
+    assert_response :ok
+    assert_equal 'body,email', response.body
+  end
+
+  def test_unencrypted_field_names_pass_through_unchanged
+    post :create, params: {
+      trap_field: '',
+      spamtrap_mutation_salt: MUTATION_SALT_HEX,
+      comment: { body: 'Hello', email: 'test@example.com' }
+    }
+
+    assert_response :ok
+    assert_equal 'body,email', response.body
+  end
+
+  def test_no_salt_leaves_encrypted_params_unmapped
+    body_token = spamtrap_encrypt_field('body', MUTATION_SALT)
+
+    post :create, params: {
+      trap_field: '',
+      comment: { body_token => 'Hello' }
+    }
+
+    assert_response :ok
+    refute_equal 'body', response.body
+  end
+
+  def test_wrong_salt_fails_to_decrypt
+    other_salt     = SecureRandom.bytes(Spamtrap::Crypto::NONCE_LEN)
+    body_token     = spamtrap_encrypt_field('body', other_salt)
+
+    post :create, params: {
+      trap_field: '',
+      spamtrap_mutation_salt: MUTATION_SALT_HEX,
+      comment: { body_token => 'Hello' }
+    }
+
+    assert_response :ok
+    refute_equal 'body', response.body
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,26 @@
 require 'rubygems'
+require 'rails'
 require 'action_controller'
+require 'action_controller/test_case'
 require 'minitest/autorun'
 require 'spamtrap'
+
+class SpamtrapTestApp < Rails::Application
+  config.secret_key_base = 'a' * 64
+  config.eager_load = false
+  config.logger = Logger.new(nil)
+end
+
+Rails.application.initialize!
+
+Rails.application.routes.draw do
+  post 'honeypot/create',      to: 'honeypot#create'
+  post 'nonce/create',         to: 'nonce#create'
+  post 'nonce_timeout/create', to: 'nonce_timeout#create'
+end
+
+class ActionController::TestCase
+  setup do
+    @routes = Rails.application.routes
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   post 'honeypot/create',      to: 'honeypot#create'
   post 'nonce/create',         to: 'nonce#create'
   post 'nonce_timeout/create', to: 'nonce_timeout#create'
+  post 'mutation/create',      to: 'mutation#create'
 end
 
 class ActionController::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   post 'nonce/create',         to: 'nonce#create'
   post 'nonce_timeout/create', to: 'nonce_timeout#create'
   post 'mutation/create',      to: 'mutation#create'
+  post 'nested_mutation/create', to: 'nested_mutation#create'
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
Three opt-in security features that layer on top of the existing honeypot to harden forms against increasingly sophisticated bots. Each can be used independently or combined.

---

## Cryptographic Nonce — replay attack protection

A basic honeypot is stateless. A bot that captures a legitimate form submission can replay it indefinitely — the honeypot field is empty, so it passes every time.

The nonce ties each submission to a timestamp, the client IP, and `secret_key_base`:

```
HMAC-SHA256(secret_key_base, "#{timestamp}:#{remote_ip}")
```

Two hidden fields are added to the form (`spamtrap_timestamp`, `spamtrap_nonce`). On submission the controller recomputes the HMAC and compares with `ActiveSupport::SecurityUtils.secure_compare` (constant-time, no timing oracle). Expired or tampered submissions are silently discarded with a `200` response.

HMAC-SHA256 is used rather than MD5 — MD5 has known collision vulnerabilities and the HMAC construction is the industry standard for message authentication.

**Controller:**
```ruby
spamtrap :my_honeypot, nonce: true, only: %i[create update]
```

**View:**
```haml
= f.spamtrap :my_honeypot, nonce: true
```

**Timeout** — default 30 minutes, configurable globally or per-action:
```ruby
Spamtrap.nonce_timeout = 1.hour                                    # initializer
spamtrap :field, nonce: true, nonce_timeout: 15.minutes            # per-action
```

> The nonce binds to `request.remote_ip`. Users whose IP changes between page load and submission (e.g. mobile network handoffs) will be rejected.

---

## Field Name Mutation — defeating field-targeting bots

Sophisticated bots parse form HTML and target fields by recognizable names — `email`, `body`, `name`, `message`. Even with a honeypot, a bot that knows the real field names can craft submissions that look legitimate.

When mutation is enabled, every field is rendered with an AES-128-GCM encrypted name instead of its real name. The salt changes on every page load, so the same field produces a different ciphertext every render — captured field names cannot be reused.

```html
<!-- rendered instead of name="comment[body]" -->
<input name="comment[YWJjZGVmZ2g...]" value="...">
<input type="hidden" name="spamtrap_mutation_salt" value="a3f9...">
```

The controller's `before_action` reads the salt, attempts decryption on every param key, and remaps successes back to their real names transparently. No changes to `params.require(...).permit(...)` are needed.

**Cryptographic design:**

| Property | Detail |
|---|---|
| Cipher | AES-128-GCM (authenticated encryption) |
| Key | HKDF-SHA256 from `secret_key_base`, label `"spamtrap-mutation"` |
| Nonce/IV | 12-byte random salt, fresh per render |
| Auth tag | 16 bytes — wrong salt = decryption failure, not wrong plaintext |
| Encoding | URL-safe Base64, no padding (~28 chars for typical field names) |

`Spamtrap::FormBuilderMutation` is prepended onto `ActionView::Helpers::FormBuilder`, intercepting 20 field helper methods. Mutation salt propagates automatically into `fields_for` child builders, so nested attributes forms are mutated at every level without additional configuration.

**Controller:**
```ruby
spamtrap :my_honeypot, mutate: true, only: %i[create update]
```

**View:**
```haml
= f.spamtrap :my_honeypot, mutate: true
= f.label :body
= f.text_area :body
```

**Combined with nonce** for full protection:
```ruby
spamtrap :my_honeypot, mutate: true, nonce: true, only: %i[create update]
```

---

## Tests

14 tests across 5 controller fixtures — 2 for the honeypot, 5 for the nonce (valid/tampered/expired/missing, custom timeout), 4 for mutation (encrypted keys remapped, plain keys pass through, missing/wrong salt), 1 for nested `fields_for` propagation. All pass.

## Files changed

| File | Change |
|---|---|
| `lib/spamtrap/crypto.rb` | New — shared AES-128-GCM encrypt/decrypt module |
| `lib/spamtrap.rb` | Global `nonce_timeout` config; require crypto |
| `lib/spamtrap/controller.rb` | `nonce:`, `nonce_timeout:`, `mutate:` options; nonce validation; param remapping |
| `lib/spamtrap/helper.rb` | `FormBuilderMutation` prepend with `fields_for` propagation; nonce + salt field generation |
| `lib/spamtrap/version.rb` | 0.2.0 → 0.3.0 |
| `test/controller_test.rb` | Full test suite replacing placeholder |
| `test/test_helper.rb` | Minimal Rails app + route setup for tests |
| `README.rdoc` | Documentation for all three features |
