### PR TITLE
Add global defaults for nonce, nonce_timeout, and mutate (v0.3.1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spamtrap (0.3.0)
+    spamtrap (0.3.1)
       rails (>= 7.0)
 
 GEM
@@ -287,7 +287,7 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  spamtrap (0.3.0)
+  spamtrap (0.3.1)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   timeout (0.6.0) sha256=6d722ad619f96ee383a0c557ec6eb8c4ecb08af3af62098a0be5057bf00de1af

--- a/README.rdoc
+++ b/README.rdoc
@@ -18,6 +18,19 @@ Add the following to your Gemfile:
 
   gem 'spamtrap'
 
+=== Configuration
+
+Global defaults can be set in an initializer. Per-controller or per-action options always
+take precedence, including an explicit <tt>false</tt> that overrides a global <tt>true</tt>.
+
+  # config/initializers/spamtrap.rb
+  Spamtrap.nonce         = true       # require nonce on all spamtrap-protected actions
+  Spamtrap.nonce_timeout = 15.minutes # default 1800 seconds (30 minutes)
+  Spamtrap.mutate        = true       # mutate field names on all protected forms
+
+These settings are read at request time, so changes take effect immediately without
+restarting the server.
+
 === Honeypot
 
 A hidden textarea is added to the form with a deliberately enticing name. Real users never see
@@ -50,31 +63,22 @@ a real form parameter at runtime.
 
 === Replay Attack Protection (Nonce)
 
-Enable cryptographic nonce validation to prevent replay attacks. The nonce is an HMAC-SHA256
-digest of the form submission timestamp and the client IP address, keyed with
-<tt>Rails.application.secret_key_base</tt>. Submissions with an expired or tampered nonce are
-silently discarded with a 200 response.
+The nonce is an HMAC-SHA256 digest of the form submission timestamp and the client IP address,
+keyed with <tt>Rails.application.secret_key_base</tt>. Submissions with an expired or tampered
+nonce are silently discarded with a 200 response.
 
-Enable it per-controller:
+Enable globally via the initializer, or per-controller:
 
-  class CommentsController < ApplicationController
-    spamtrap :sarah_palin_walks_with_dinosaurs, nonce: true, only: %i(create update)
-  end
+  spamtrap :sarah_palin_walks_with_dinosaurs, nonce: true, only: %i(create update)
 
-And add the nonce fields to your form:
+Add the nonce fields to your form:
 
   - form_for @comment do |f|
     = f.spamtrap :sarah_palin_walks_with_dinosaurs, nonce: true, class: 'reindeer_jerky'
 
-Override the timeout for a specific controller action (accepts any value in seconds, or an
-ActiveSupport duration):
+Override the timeout for a specific action (accepts seconds or an ActiveSupport duration):
 
   spamtrap :field, nonce: true, nonce_timeout: 15.minutes, only: %i(create)
-
-Set a global default timeout in an initializer (default is 1800 seconds / 30 minutes):
-
-  # config/initializers/spamtrap.rb
-  Spamtrap.nonce_timeout = 1.hour
 
 Note: because the nonce binds to the client IP, users whose IP address changes between page load
 and form submission (e.g. mobile network handoffs) will be rejected. This is an acceptable
@@ -82,18 +86,16 @@ trade-off for spam protection but may not suit all deployments.
 
 === Field Name Mutation
 
-Enable field name mutation to make all form fields unrecognizable in HTML source. Every field
-is encrypted with AES-128-GCM using a random per-render salt, so field names change on every
-page load. The controller decrypts and remaps them transparently before the action runs — no
-changes to <tt>params.require(...).permit(...)</tt> or any other controller code required.
+Every field is encrypted with AES-128-GCM using a random per-render salt, so field names are
+unrecognizable in HTML source and change on every page load. The controller decrypts and remaps
+them transparently before the action runs — no changes to
+<tt>params.require(...).permit(...)</tt> or any other controller code required.
 
-Enable mutation in the controller:
+Enable globally via the initializer, or per-controller:
 
-  class CommentsController < ApplicationController
-    spamtrap :sarah_palin_walks_with_dinosaurs, mutate: true, only: %i(create update)
-  end
+  spamtrap :sarah_palin_walks_with_dinosaurs, mutate: true, only: %i(create update)
 
-Enable it in the view by passing <tt>mutate: true</tt> to <tt>f.spamtrap</tt>:
+Pass <tt>mutate: true</tt> to <tt>f.spamtrap</tt> in your view:
 
   - form_for @comment do |f|
     = f.spamtrap :sarah_palin_walks_with_dinosaurs, mutate: true

--- a/lib/spamtrap.rb
+++ b/lib/spamtrap.rb
@@ -2,10 +2,18 @@ require 'openssl'
 
 module Spamtrap
   class << self
-    attr_writer :nonce_timeout
+    attr_writer :nonce, :nonce_timeout, :mutate
+
+    def nonce
+      @nonce || false
+    end
 
     def nonce_timeout
       @nonce_timeout || 1800
+    end
+
+    def mutate
+      @mutate || false
     end
   end
 

--- a/lib/spamtrap/controller.rb
+++ b/lib/spamtrap/controller.rb
@@ -7,13 +7,19 @@ module Spamtrap::Controller
 
   module ActsAsMethods
     def spamtrap(honeypot = 'spamtrap', options = {}, &block)
-      nonce_enabled  = options.delete(:nonce)
-      nonce_timeout  = options.delete(:nonce_timeout) || Spamtrap.nonce_timeout
-      mutate_enabled = options.delete(:mutate)
+      # Capture explicit per-call values; use sentinel so globals are read
+      # at request time rather than at class definition time.
+      nonce_opt   = options.key?(:nonce)         ? options.delete(:nonce)         : :global
+      timeout_opt = options.key?(:nonce_timeout) ? options.delete(:nonce_timeout) : :global
+      mutate_opt  = options.key?(:mutate)        ? options.delete(:mutate)        : :global
 
       before_action(options) do |controller|
         controller.instance_eval(&block) if block_given?
         controller.instance_eval do
+          nonce_enabled  = nonce_opt   == :global ? Spamtrap.nonce         : nonce_opt
+          nonce_timeout  = timeout_opt == :global ? Spamtrap.nonce_timeout : timeout_opt
+          mutate_enabled = mutate_opt  == :global ? Spamtrap.mutate        : mutate_opt
+
           spamtrap_remap_params if mutate_enabled
 
           if params[honeypot].present?

--- a/lib/spamtrap/helper.rb
+++ b/lib/spamtrap/helper.rb
@@ -38,8 +38,8 @@ class ActionView::Helpers::FormBuilder
   prepend Spamtrap::FormBuilderMutation
 
   def spamtrap(parameter = 'spamtrap', options = {})
-    mutate = options.delete(:mutate)
-    nonce  = options.delete(:nonce)
+    mutate = options.key?(:mutate) ? options.delete(:mutate) : Spamtrap.mutate
+    nonce  = options.key?(:nonce)  ? options.delete(:nonce)  : Spamtrap.nonce
     options.reverse_merge!(class: 'spamtrap')
 
     if mutate

--- a/lib/spamtrap/version.rb
+++ b/lib/spamtrap/version.rb
@@ -1,5 +1,5 @@
 module Spamtrap
 
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -242,3 +242,106 @@ class NestedMutationControllerTest < ActionController::TestCase
     assert_equal 'body;city,street', response.body
   end
 end
+
+# Controller that relies entirely on global defaults (no per-call options).
+class GlobalDefaultsController < ActionController::Base
+  spamtrap :trap_field, only: :create
+
+  def create
+    render plain: params[:comment].to_unsafe_h.keys.sort.join(',')
+  end
+end
+
+# Controller that explicitly overrides global defaults with false.
+class GlobalOverrideController < ActionController::Base
+  spamtrap :trap_field, nonce: false, mutate: false, only: :create
+
+  def create
+    render plain: params[:comment].to_unsafe_h.keys.sort.join(',')
+  end
+end
+
+class GlobalDefaultsControllerTest < ActionController::TestCase
+  include MutationTestHelper
+  include NonceTestHelper
+  tests GlobalDefaultsController
+
+  setup do
+    Spamtrap.nonce  = true
+    Spamtrap.mutate = true
+  end
+
+  teardown do
+    Spamtrap.nonce  = false
+    Spamtrap.mutate = false
+  end
+
+  def test_global_nonce_default_rejects_missing_nonce
+    post :create, params: { trap_field: '', comment: { body: 'Hello' } }
+    assert_response :ok
+    assert_empty response.body
+  end
+
+  def test_global_nonce_default_accepts_valid_nonce
+    timestamp = Time.now.to_i
+    post :create, params: {
+      trap_field: '',
+      spamtrap_timestamp: timestamp,
+      spamtrap_nonce: generate_nonce(timestamp),
+      spamtrap_mutation_salt: MUTATION_SALT_HEX,
+      comment: { spamtrap_encrypt_field('body', MUTATION_SALT) => 'Hello' }
+    }
+    assert_response :ok
+    assert_equal 'body', response.body
+  end
+
+  def test_global_mutate_default_remaps_encrypted_fields
+    body_token = spamtrap_encrypt_field('body', MUTATION_SALT)
+    timestamp  = Time.now.to_i
+    post :create, params: {
+      trap_field: '',
+      spamtrap_timestamp: timestamp,
+      spamtrap_nonce: generate_nonce(timestamp),
+      spamtrap_mutation_salt: MUTATION_SALT_HEX,
+      comment: { body_token => 'Hello' }
+    }
+    assert_response :ok
+    assert_equal 'body', response.body
+  end
+end
+
+class GlobalOverrideControllerTest < ActionController::TestCase
+  include MutationTestHelper
+  tests GlobalOverrideController
+
+  setup do
+    Spamtrap.nonce  = true
+    Spamtrap.mutate = true
+  end
+
+  teardown do
+    Spamtrap.nonce  = false
+    Spamtrap.mutate = false
+  end
+
+  def test_per_call_false_overrides_global_nonce
+    # No nonce params — would fail if global nonce: true were in effect
+    post :create, params: {
+      trap_field: '',
+      comment: { body: 'Hello' }
+    }
+    assert_response :ok
+    assert_equal 'body', response.body
+  end
+
+  def test_per_call_false_overrides_global_mutate
+    # Plain field name — would be remapped if global mutate: true were in effect
+    post :create, params: {
+      trap_field: '',
+      spamtrap_mutation_salt: MUTATION_SALT_HEX,
+      comment: { body: 'Hello' }
+    }
+    assert_response :ok
+    assert_equal 'body', response.body
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
   post 'nonce/create',         to: 'nonce#create'
   post 'nonce_timeout/create', to: 'nonce_timeout#create'
   post 'mutation/create',      to: 'mutation#create'
-  post 'nested_mutation/create', to: 'nested_mutation#create'
+  post 'nested_mutation/create',  to: 'nested_mutation#create'
+  post 'global_defaults/create',  to: 'global_defaults#create'
+  post 'global_override/create',  to: 'global_override#create'
 end
 
 class ActionController::TestCase


### PR DESCRIPTION
All three options can now be configured in an initializer and overridden per-controller or per-action. Globals are resolved at request time so an explicit false at the call site correctly overrides a global true.